### PR TITLE
Forbid access to errors.log

### DIFF
--- a/anchor/.htaccess
+++ b/anchor/.htaccess
@@ -1,1 +1,4 @@
+<Files "errors.log">
+Order Allow,Deny
 Deny from all
+</Files> 


### PR DESCRIPTION
In response to CVE-2018-7251 , all web access was denied to /anchor important assets directories

### Fix/Feature for #1249
Hence, I am only disallowing access to logs file because the previous fix turned out to be a bit buggy

### Changes proposed:

-  +Deny from all directive has been replaced with 
<Files "errors.log">
Order Allow,Deny
Deny from all
</Files> 
